### PR TITLE
Support multiple architectures, added some ABI input validation 

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -70,11 +70,11 @@ pub fn gen_android_mk_con(mk: &Androidmk) {
     mk_file_content.push_str(&format!("LOCAL_SRC_FILES := {}\n", apk_dir.display()));
 
     let native_libraries = mk.get_libraries();
-    let architecture = mk.get_default_architecture();
-    if native_libraries.len() > 0 {
-        mk_file_content.push_str("\n");
-        mk_file_content.push_str("LOCAL_PREBUILT_JNI_LIBS := \\\n");
-
+    let architectures = mk.get_architectures();
+    let lib_size = native_libraries.len();
+    
+    //If we have some native libs, start writing to makefile for them
+    if lib_size > 0 {
         let lib_type = if mk.extract_so() {
             //TODO: maybe rm -rf * this dir before extracting?
             extract_zip(mk);
@@ -85,9 +85,22 @@ pub fn gen_android_mk_con(mk: &Androidmk) {
             " @lib"
         };
 
-        for key in native_libraries {
-            mk_file_content.push_str(&format!("  {}/{}/{}", lib_type, architecture, key));
-            mk_file_content.push_str(" \\\n");
+        mk_file_content.push_str("\n");
+        mk_file_content.push_str("LOCAL_PREBUILT_JNI_LIBS := \\\n");
+
+        if mk.has_default_architecture() {
+            let default_arch = mk.get_default_architecture();
+            for lib in native_libraries {
+                mk_file_content.push_str(&format!("  {}/{}/{}", lib_type, default_arch, lib));
+                mk_file_content.push_str(" \\\n");
+            }
+        } else {
+            for arch in architectures {
+                for lib in &native_libraries {
+                    mk_file_content.push_str(&format!("  {}/{}/{}", lib_type, arch, lib));
+                    mk_file_content.push_str(" \\\n");
+                }
+            }
         }
     } else {
         mk.log("No native libraries found!");

--- a/tests/architectures.rs
+++ b/tests/architectures.rs
@@ -2,7 +2,7 @@ use genandroidmk_rs::makefile::Androidmk;
 
 mod helper;
 
-use helper::{get_by_name, get_random_mk, mk_contains};
+use helper::{cleanup_path, file_exists, get_by_name, get_random_mk, mk_contains};
 
 // https://developer.android.com/studio/projects/gradle-external-native-builds#specify-abi
 
@@ -16,14 +16,15 @@ fn architectures_tests() {
 
 #[should_panic]
 #[test]
-fn more_than_one_architecture_panic() {
+fn invalid_abi_panic() {
     // The multipleArch apk supports mutltiple architectures
-    // and we haven't set a default architecture here
+    // If we set an architecture it doesn't exist, it should panic and exit
+    // In this case, armeabi-v5 isn't valid
     let _ = Androidmk::new(
         "tests/data/multipleArch.apk", // input
         "multipleArch",                // name
-        "",                            // default_architecture
-        false,                         // has default architecture
+        "armeabi-v5",                  // default_architecture
+        true,                          // has default architecture
         "6.0",                         // (un-used) os version
         false,                         // pre-optimize dex files
         false,                         // priviledged
@@ -75,4 +76,60 @@ fn default_armeabi_v7a() {
         mk_contains("@lib/armeabi-v7a/libhello-jnicallback.so"),
         true
     );
+}
+
+#[test]
+fn multiple_arch_default_extract() {
+    cleanup_path("lib/");
+    let mut mk = get_by_name("multipleArch");
+    mk.set_extract_so(true);
+    mk.gen_android_mk();
+    let libhello_jnicallback_arm64_v8a = "lib/arm64-v8a/libhello-jnicallback.so";
+    let libhello_jnicallback_armeabi_v7a = "lib/armeabi-v7a/libhello-jnicallback.so";
+    let libhello_jnicallback_x86 = "lib/x86/libhello-jnicallback.so";
+    let libhello_jnicallback_x86_64 = "lib/x86_64/libhello-jnicallback.so";
+
+    assert_eq!(file_exists(libhello_jnicallback_arm64_v8a), true);
+    assert_eq!(file_exists(libhello_jnicallback_armeabi_v7a), true);
+    assert_eq!(file_exists(libhello_jnicallback_x86), true);
+    assert_eq!(file_exists(libhello_jnicallback_x86_64), true);
+    cleanup_path("lib/");
+}
+
+#[test]
+fn multiple_arch_only_armeabi_v7a_extract() {
+    cleanup_path("lib/");
+    let mut mk = get_by_name("multipleArch");
+    mk.set_extract_so(true);
+    mk.set_default_architecture("armeabi-v7a".into());
+    mk.set_has_default_architecture(true);
+    mk.gen_android_mk();
+    let libhello_jnicallback_arm64_v8a = "lib/arm64-v8a/libhello-jnicallback.so";
+    let libhello_jnicallback_armeabi_v7a = "lib/armeabi-v7a/libhello-jnicallback.so";
+    let libhello_jnicallback_x86 = "lib/x86/libhello-jnicallback.so";
+    let libhello_jnicallback_x86_64 = "lib/x86_64/libhello-jnicallback.so";
+
+    assert_eq!(file_exists(libhello_jnicallback_arm64_v8a), false);
+    assert_eq!(file_exists(libhello_jnicallback_armeabi_v7a), true);
+    assert_eq!(file_exists(libhello_jnicallback_x86), false);
+    assert_eq!(file_exists(libhello_jnicallback_x86_64), false);
+    cleanup_path("lib/");
+}
+
+#[test]
+fn x86_arch_multiple_so() {
+    cleanup_path("lib/");
+    let mut mk = get_by_name("x86_multiple_so");
+    mk.set_extract_so(true);
+    mk.gen_android_mk();
+    let libhello_jnicallback_x86 = "lib/x86/libhello-jnicallback.so";
+    let liblibtest_gen_x86 = "lib/x86/libtest_gen.so";
+    let libhello_jnicallback_arm64_v8a = "lib/arm64-v8a/libhello-jnicallback.so";
+    let libhello_jnicallback_x86_64 = "lib/x86_64/libhello-jnicallback.so";
+
+    assert_eq!(file_exists(liblibtest_gen_x86), true);
+    assert_eq!(file_exists(libhello_jnicallback_x86), true);
+    assert_eq!(file_exists(libhello_jnicallback_arm64_v8a), false);
+    assert_eq!(file_exists(libhello_jnicallback_x86_64), false);
+    cleanup_path("lib/");
 }

--- a/tests/native_libs.rs
+++ b/tests/native_libs.rs
@@ -97,3 +97,61 @@ fn extract_multiple_libs() {
     assert_eq!(file_exists(lib_test_noop_so), false);
     cleanup_path("lib/");
 }
+
+#[test]
+fn extract_multiple_arch_libs() {
+    cleanup_path("lib/");
+    let mut mk = get_by_name("multipleArch");
+    mk.set_extract_so(true);
+    // mk.set_default_architecture("armeabi-v7a".into());
+    // mk.set_has_default_architecture(true);
+    mk.gen_android_mk();
+    let libhello_jnicallback_arm64_v8a = "lib/arm64-v8a/libhello-jnicallback.so";
+    let libhello_jnicallback_armeabi_v7a = "lib/armeabi-v7a/libhello-jnicallback.so";
+    let libhello_jnicallback_x86 = "lib/x86/libhello-jnicallback.so";
+    let libhello_jnicallback_x86_64 = "lib/x86_64/libhello-jnicallback.so";
+
+    assert_eq!(mk_contains(libhello_jnicallback_arm64_v8a), true);
+    assert_eq!(mk_contains(libhello_jnicallback_armeabi_v7a), true);
+    assert_eq!(mk_contains(libhello_jnicallback_x86), true);
+    assert_eq!(mk_contains(libhello_jnicallback_x86_64), true);
+    cleanup_path("lib/");
+}
+
+#[test]
+fn non_extract_multiple_arch_libs() {
+    cleanup_path("lib/");
+    let mut mk = get_by_name("multipleArch");
+    mk.set_extract_so(false);
+    mk.gen_android_mk();
+    let libhello_jnicallback_arm64_v8a = "@lib/arm64-v8a/libhello-jnicallback.so";
+    let libhello_jnicallback_armeabi_v7a = "@lib/armeabi-v7a/libhello-jnicallback.so";
+    let libhello_jnicallback_x86 = "@lib/x86/libhello-jnicallback.so";
+    let libhello_jnicallback_x86_64 = "@lib/x86_64/libhello-jnicallback.so";
+
+    assert_eq!(mk_contains(libhello_jnicallback_arm64_v8a), true);
+    assert_eq!(mk_contains(libhello_jnicallback_armeabi_v7a), true);
+    assert_eq!(mk_contains(libhello_jnicallback_x86), true);
+    assert_eq!(mk_contains(libhello_jnicallback_x86_64), true);
+    cleanup_path("lib/");
+}
+
+#[test]
+fn extract_single_arch_libs() {
+    cleanup_path("lib/");
+    let mut mk = get_by_name("x86_multiple_so");
+    mk.set_extract_so(true);
+    mk.set_default_architecture("x86".into());
+    mk.set_has_default_architecture(true);
+    mk.gen_android_mk();
+    let libhello_jnicallback_arm64_v8a = "lib/armeabi-v7a/libhello-jnicallback.so";
+    let libhello_jnicallback_armeabi_v7a = "lib/armeabi-v7a/libhello-jnicallback.so";
+    let libhello_jnicallback_x86 = "lib/x86/libhello-jnicallback.so";
+    let libhello_jnicallback_x86_64 = "lib/x86_64/libhello-jnicallback.so";
+
+    assert_eq!(mk_contains(libhello_jnicallback_arm64_v8a), false);
+    assert_eq!(mk_contains(libhello_jnicallback_armeabi_v7a), false);
+    assert_eq!(mk_contains(libhello_jnicallback_x86), true);
+    assert_eq!(mk_contains(libhello_jnicallback_x86_64), false);
+    cleanup_path("lib/");
+}


### PR DESCRIPTION
Closes #1 

Adds validation for input when default architecture is requested.

Enables the ability to generate multiple architectures for the makefiles.

Added 6 new tests for further validation on the tool.