### PR TITLE
Ability to pass multiple architectures with -a --arch flag.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "genandroidmk_rs"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genandroidmk_rs"
-version = "0.1.0"
+version = "1.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["Behxhet Sadiku <bensadiku65@gmail.com>"]
 edition = "2018"

--- a/src/file.rs
+++ b/src/file.rs
@@ -89,7 +89,7 @@ pub fn gen_android_mk_con(mk: &Androidmk) {
         // If we passed some architectures via cli, prioritize those
         // Else, use the architectures we found in APK
         let arch = if mk.has_default_architecture() {
-            mk.get_default_architecture()
+            mk.get_default_architectures()
         } else {
             mk.get_architectures()
         };

--- a/src/file.rs
+++ b/src/file.rs
@@ -70,9 +70,7 @@ pub fn gen_android_mk_con(mk: &Androidmk) {
     mk_file_content.push_str(&format!("LOCAL_SRC_FILES := {}\n", apk_dir.display()));
 
     let native_libraries = mk.get_libraries();
-    let architectures = mk.get_architectures();
     let lib_size = native_libraries.len();
-    
     //If we have some native libs, start writing to makefile for them
     if lib_size > 0 {
         let lib_type = if mk.extract_so() {
@@ -88,18 +86,17 @@ pub fn gen_android_mk_con(mk: &Androidmk) {
         mk_file_content.push_str("\n");
         mk_file_content.push_str("LOCAL_PREBUILT_JNI_LIBS := \\\n");
 
-        if mk.has_default_architecture() {
-            let default_arch = mk.get_default_architecture();
-            for lib in native_libraries {
-                mk_file_content.push_str(&format!("  {}/{}/{}", lib_type, default_arch, lib));
-                mk_file_content.push_str(" \\\n");
-            }
+        // If we passed some architectures via cli, prioritize those
+        // Else, use the architectures we found in APK
+        let arch = if mk.has_default_architecture() {
+            mk.get_default_architecture()
         } else {
-            for arch in architectures {
-                for lib in &native_libraries {
-                    mk_file_content.push_str(&format!("  {}/{}/{}", lib_type, arch, lib));
-                    mk_file_content.push_str(" \\\n");
-                }
+            mk.get_architectures()
+        };
+        for archi in arch {
+            for lib in &native_libraries {
+                mk_file_content.push_str(&format!("  {}/{}/{}", lib_type, archi, lib));
+                mk_file_content.push_str(" \\\n");
             }
         }
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod file;
 mod zip;
 
+pub mod utils;
 pub mod makefile;
 pub use makefile::Androidmk;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod file;
 mod makefile;
+mod utils;
 mod zip;
 
 use makefile::Androidmk;

--- a/src/makefile.rs
+++ b/src/makefile.rs
@@ -12,7 +12,7 @@ use super::utils;
 pub struct Androidmk {
     input: String,
     name: String,
-    default_architecture: Vec<String>,
+    default_architectures: Vec<String>,
     has_default_architecture: bool,
     os: String,
     preopt_dex: bool,
@@ -62,7 +62,7 @@ impl Androidmk {
         let mut m = Self {
             input: input_string,
             name: name_string,
-            default_architecture: default_architectures,
+            default_architectures: default_architectures,
             has_default_architecture: has_default,
             os: os.into(),
             preopt_dex: preopt_dex,
@@ -92,7 +92,7 @@ impl Androidmk {
             let arch = architectures[0].clone();
             let msg = format!("Only one architecture, autochoosing {}", arch);
             self.log(msg);
-            self.set_default_architecture(architectures);
+            self.set_default_architectures(architectures);
         }
     }
 
@@ -104,12 +104,12 @@ impl Androidmk {
         self.input.clone()
     }
 
-    pub fn get_default_architecture(&self) -> Vec<String> {
-        self.default_architecture.clone()
+    pub fn get_default_architectures(&self) -> Vec<String> {
+        self.default_architectures.clone()
     }
 
-    pub fn set_default_architecture(&mut self, default_architecture: Vec<String>) {
-        self.default_architecture = default_architecture;
+    pub fn set_default_architectures(&mut self, default_architectures: Vec<String>) {
+        self.default_architectures = default_architectures;
     }
 
     // pub fn get_os(&self) -> String {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,21 @@
+/// Should check if the inputted ABI's are valid
+/// Convert the String to a list of ABI's
+pub fn input_to_abi_vec(input: &str) -> Vec<String> {
+    if input.is_empty() {
+        return vec![];
+    }
+    let list: Vec<String> = input.split(",").map(|s| s.to_string()).collect();
+    for abi in &list {
+        // If there's a default architecture supplied but it's not a valid one
+        // e.g a typo, exit immediately, see issue #1
+        if !VALID_ABI.contains(&abi.as_ref()) {
+            panic!(
+                "{} is not a valid ABI. Use commas to separate them e.g armeabi-v7a,arm64-v8a \n\n Must be one of {:?}",
+                abi, VALID_ABI
+            );
+        }
+    }
+    return list;
+}
+
+pub const VALID_ABI: &[&str] = &["armeabi-v7a", "arm64-v8a", "x86", "x86_64"];

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::{Read, Seek};
-use std::path::Path;
 use zip::read::ZipArchive;
 use zip::read::ZipFile;
 use zip::result::ZipResult;
@@ -36,13 +35,13 @@ where
 }
 
 pub fn extract_zip(mk: &Androidmk) {
-    let default_architecture = mk.get_default_architecture();
+    let default_architectures = mk.get_default_architecture();
     let input = &mk.get_input();
     let fname = std::path::Path::new(input);
     if mk.has_default_architecture() {
         mk.log(format!(
-            "Extracting: {:?} for architecture {} ",
-            fname, default_architecture
+            "Extracting: {:?} for architecture {:?} ",
+            fname, mk.get_default_architecture()
         ));
     } else {
         mk.log(format!(
@@ -77,8 +76,9 @@ pub fn extract_zip(mk: &Androidmk) {
             if let Some(p) = outpath.parent() {
                 // If we specified a default architecture, check if the one we're extracting matches
                 if mk.has_default_architecture() {
-                    let directory_arch = p.file_name().unwrap().to_str().unwrap();
-                    if directory_arch == default_architecture {
+                    // FIXME: This is super lazy.. 
+                    let directory_arch = p.file_name().unwrap().to_str().unwrap().to_string();
+                    if default_architectures.contains(&directory_arch) {
                         if !p.exists() {
                             fs::create_dir_all(&p).unwrap();
                         }

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -35,13 +35,13 @@ where
 }
 
 pub fn extract_zip(mk: &Androidmk) {
-    let default_architectures = mk.get_default_architecture();
+    let default_architectures = mk.get_default_architectures();
     let input = &mk.get_input();
     let fname = std::path::Path::new(input);
     if mk.has_default_architecture() {
         mk.log(format!(
             "Extracting: {:?} for architecture {:?} ",
-            fname, mk.get_default_architecture()
+            fname, mk.get_default_architectures()
         ));
     } else {
         mk.log(format!(

--- a/tests/architectures.rs
+++ b/tests/architectures.rs
@@ -37,7 +37,7 @@ fn invalid_abi_panic() {
 fn default_arch() {
     let mk = get_random_mk();
     let _ret2 = mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), vec!["arm64-v8a"]);
+    assert_eq!(mk.get_default_architectures(), vec!["arm64-v8a"]);
     assert_eq!(mk.has_default_architecture(), true);
     assert_eq!(mk_contains("@lib/arm64-v8a/libhello-jnicallback.so"), true);
 }
@@ -56,7 +56,7 @@ fn force_x86() {
         true,                                  // debug flag
     );
     let _ret2 = &mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), vec!["x86"]);
+    assert_eq!(mk.get_default_architectures(), vec!["x86"]);
     assert_eq!(mk_contains("@lib/x86/libhello-jnicallback.so"), true);
 }
 
@@ -64,7 +64,7 @@ fn force_x86() {
 fn default_x86() {
     let mk = get_by_name("x86");
     let _ret2 = mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), vec!["x86"]);
+    assert_eq!(mk.get_default_architectures(), vec!["x86"]);
     assert_eq!(mk_contains("@lib/x86/libhello-jnicallback.so"), true);
 }
 
@@ -72,7 +72,7 @@ fn default_x86() {
 fn default_x86_2() {
     let mk = get_by_name("x86_multiple_so");
     let _ret2 = mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), vec!["x86"]);
+    assert_eq!(mk.get_default_architectures(), vec!["x86"]);
     assert_eq!(mk_contains("@lib/x86/libhello-jnicallback.so"), true);
 }
 
@@ -80,7 +80,7 @@ fn default_x86_2() {
 fn default_armeabi_v7a() {
     let mk = get_by_name("armeabi-v7a");
     let _ret2 = mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), vec!["armeabi-v7a"]);
+    assert_eq!(mk.get_default_architectures(), vec!["armeabi-v7a"]);
     assert_eq!(
         mk_contains("@lib/armeabi-v7a/libhello-jnicallback.so"),
         true

--- a/tests/architectures.rs
+++ b/tests/architectures.rs
@@ -37,17 +37,26 @@ fn invalid_abi_panic() {
 fn default_arch() {
     let mk = get_random_mk();
     let _ret2 = mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), "arm64-v8a");
+    assert_eq!(mk.get_default_architecture(), vec!["arm64-v8a"]);
     assert_eq!(mk.has_default_architecture(), true);
     assert_eq!(mk_contains("@lib/arm64-v8a/libhello-jnicallback.so"), true);
 }
 
 #[test]
 fn force_x86() {
-    let mut mk = get_random_mk();
-    mk.set_default_architecture("x86".into());
-    let _ret2 = mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), "x86");
+    let mk = Androidmk::new(
+        format!("tests/data/armeabi-v7a.apk"), // input
+        "armeabi-v7a",                         // name
+        "x86",                                 // default_architecture
+        true,                                  // has default architecture
+        "6.0",                                 // (un-used) os version
+        false,                                 // pre-optimize dex files
+        false,                                 // priviledged
+        false,                                 // extract_so
+        true,                                  // debug flag
+    );
+    let _ret2 = &mk.gen_android_mk();
+    assert_eq!(mk.get_default_architecture(), vec!["x86"]);
     assert_eq!(mk_contains("@lib/x86/libhello-jnicallback.so"), true);
 }
 
@@ -55,7 +64,7 @@ fn force_x86() {
 fn default_x86() {
     let mk = get_by_name("x86");
     let _ret2 = mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), "x86");
+    assert_eq!(mk.get_default_architecture(), vec!["x86"]);
     assert_eq!(mk_contains("@lib/x86/libhello-jnicallback.so"), true);
 }
 
@@ -63,7 +72,7 @@ fn default_x86() {
 fn default_x86_2() {
     let mk = get_by_name("x86_multiple_so");
     let _ret2 = mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), "x86");
+    assert_eq!(mk.get_default_architecture(), vec!["x86"]);
     assert_eq!(mk_contains("@lib/x86/libhello-jnicallback.so"), true);
 }
 
@@ -71,7 +80,7 @@ fn default_x86_2() {
 fn default_armeabi_v7a() {
     let mk = get_by_name("armeabi-v7a");
     let _ret2 = mk.gen_android_mk();
-    assert_eq!(mk.get_default_architecture(), "armeabi-v7a");
+    assert_eq!(mk.get_default_architecture(), vec!["armeabi-v7a"]);
     assert_eq!(
         mk_contains("@lib/armeabi-v7a/libhello-jnicallback.so"),
         true
@@ -99,9 +108,18 @@ fn multiple_arch_default_extract() {
 #[test]
 fn multiple_arch_only_armeabi_v7a_extract() {
     cleanup_path("lib/");
-    let mut mk = get_by_name("multipleArch");
+    let mut mk = Androidmk::new(
+        format!("tests/data/multipleArch.apk"), // input
+        "multipleArch",                         // name
+        "armeabi-v7a",                          // default_architecture
+        true,                                   // has default architecture
+        "6.0",                                  // (un-used) os version
+        false,                                  // pre-optimize dex files
+        false,                                  // priviledged
+        false,                                  // extract_so
+        true,                                   // debug flag
+    );
     mk.set_extract_so(true);
-    mk.set_default_architecture("armeabi-v7a".into());
     mk.set_has_default_architecture(true);
     mk.gen_android_mk();
     let libhello_jnicallback_arm64_v8a = "lib/arm64-v8a/libhello-jnicallback.so";

--- a/tests/input.rs
+++ b/tests/input.rs
@@ -5,6 +5,7 @@ use helper::get_random_mk;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use genandroidmk_rs::utils::input_to_abi_vec;
 
     // run with `cargo test -- --nocapture` for  the logs
     // run with `cargo test -- --test-threads=1` for single threaded tests
@@ -13,10 +14,9 @@ mod tests {
         let current_dir = env::current_dir().unwrap();
         println!("current_dir {:?}", current_dir);
 
-        let mut mk = get_random_mk();
-        mk.set_default_architecture("arm64-v8a".into());
+        let mk = get_random_mk();
         let _ret2 = mk.gen_android_mk();
-        assert_eq!(mk.get_default_architecture(), "arm64-v8a");
+        assert_eq!(mk.get_default_architecture(),vec!["arm64-v8a"]);
         assert_eq!(mk.privileged(), false);
         assert_eq!(mk.get_preopt_dex(), false);
         assert_eq!(helper::mk_contains("LOCAL_DEX_PREOPT"), false);
@@ -51,5 +51,22 @@ mod tests {
         let _ret = mk.gen_android_mk();
         let so_files = vec!["libhello-jnicallback.so"];
         assert_eq!(mk.get_libraries(), so_files);
+    }
+
+    #[test]
+    fn valid_architecture_input() {
+        let multiple_arch_input = "armeabi-v7a,x86";
+        let arch = vec!["armeabi-v7a", "x86"];
+        let parsed = input_to_abi_vec(multiple_arch_input);
+        assert_eq!(arch, parsed);
+    }
+
+    #[should_panic]
+    #[test]
+    fn invalid_architecture_input() {
+        let multiple_arch_input = "armeabi-v7a,x85";
+        let arch = vec!["armeabi-v7a", "x86"];
+        let parsed = input_to_abi_vec(multiple_arch_input);
+        assert_eq!(arch, parsed);
     }
 }

--- a/tests/input.rs
+++ b/tests/input.rs
@@ -16,7 +16,7 @@ mod tests {
 
         let mk = get_random_mk();
         let _ret2 = mk.gen_android_mk();
-        assert_eq!(mk.get_default_architecture(),vec!["arm64-v8a"]);
+        assert_eq!(mk.get_default_architectures(),vec!["arm64-v8a"]);
         assert_eq!(mk.privileged(), false);
         assert_eq!(mk.get_preopt_dex(), false);
         assert_eq!(helper::mk_contains("LOCAL_DEX_PREOPT"), false);

--- a/tests/native_libs.rs
+++ b/tests/native_libs.rs
@@ -139,9 +139,18 @@ fn non_extract_multiple_arch_libs() {
 #[test]
 fn extract_single_arch_libs() {
     cleanup_path("lib/");
-    let mut mk = get_by_name("x86_multiple_so");
+    let mut mk = Androidmk::new(
+        format!("tests/data/x86_multiple_so.apk"), // input
+        "x86_multiple_so",                         // name
+        "x86",                                     // default_architecture
+        true,                                      // has default architecture
+        "6.0",                                     // (un-used) os version
+        false,                                     // pre-optimize dex files
+        false,                                     // priviledged
+        false,                                     // extract_so
+        true,                                      // debug flag
+    );
     mk.set_extract_so(true);
-    mk.set_default_architecture("x86".into());
     mk.set_has_default_architecture(true);
     mk.gen_android_mk();
     let libhello_jnicallback_arm64_v8a = "lib/armeabi-v7a/libhello-jnicallback.so";


### PR DESCRIPTION
#3 

Aims to add multiple architectures with the -a flag.
Whatever is passed with -a flag, is the default, architectures in APK will be ignored. If there's a typo, it will exit with a helpful error message.
Usage as follows:
`-a arm64-v8a,x86`
 will generate:
 ```makefile
 LOCAL_PREBUILT_JNI_LIBS := \
   @lib/arm64-v8a/<lib>.so \
   @lib/x86/<lib>.so
   ...
   ```
   
   Modified and added some new tests for this case.